### PR TITLE
[박동현] 결과 화면 만들기

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,15 @@
 
 
 ## Task 6
+### Main 화면 - 결과 화면 연결
+* `registerForActivityResult`로 연결: deprecated된 `startActivityForResult` 대신 활용.  
+승자 확인 화면의 Result로 `userCount`를 전달받아 그에 맞게 게임을 리셋 (근데 이제보니 `LuckyGame`에 저장된 변수라서 굳이 전달받을 필요가 있나 싶긴 하다.)
+* `startResult: ActivityResultLauncher`: ViewModel의 `endFlag`가 `true`가 되면, 승자가 존재하는지 확인 후에 존재한다면 `startResult`의 `launch` 함수로 GameResultActivity`로 이동
+
+### 승자 판단 기능 추가 구현
+* `matchedCardsOfUsers: MutableMap<Int, Set<Int>`: 유저 별 3장 매칭된 카드의 번호를 기록
+
+### 결과 화면 구현 - `GameResultActivity` & `GameResultComposable`
+* `GameResultViewModel`: View가 화면에 그려지기 전에 `LuckyGame`의 게임 결과 관련 데이터를 참조하여 `StateFlow`에 보관
+* `onBackPressedDispatcher`: deprecated된 `onBackPressed`를 대신해 사용. 결과화면에서 백버튼으로 Main 화면으로 가지 못하게 차단.
+* 이외 `GameResultActivity`의 레이아웃은 Compose로 구현

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,10 @@ android {
     }
     buildFeatures {
         dataBinding true
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.6"
     }
 }
 
@@ -56,4 +60,15 @@ dependencies {
     // hilt
     implementation 'com.google.dagger:hilt-android:2.46.1'
     kapt 'com.google.dagger:hilt-compiler:2.46.1'
+
+    // Compose
+    def composeBom = platform('androidx.compose:compose-bom:2023.06.01')
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.1"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
         android:theme="@style/Theme.LuckyCardGame"
         tools:targetApi="31">
         <activity
+            android:name=".presentation.result.GameResultActivity"
+            android:exported="false" />
+        <activity
             android:name=".presentation.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.LuckyCardGame" >

--- a/app/src/main/java/com/example/luckycardgame/data/model/LuckyGame.kt
+++ b/app/src/main/java/com/example/luckycardgame/data/model/LuckyGame.kt
@@ -251,7 +251,7 @@ class LuckyGame(
 
     fun getWinners() = this.winners
 
-    fun getCardsOfWinners() = matchedCardsOfUsers
+    fun getMatchedCardsOfUsers() = matchedCardsOfUsers
 
     private fun setUserCount(userCount: Int) {
         this.userCount = userCount

--- a/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultActivity.kt
+++ b/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultActivity.kt
@@ -1,0 +1,62 @@
+package com.example.luckycardgame.presentation.result
+
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.addCallback
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.example.luckycardgame.presentation.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+
+@AndroidEntryPoint
+class GameResultActivity : ComponentActivity() {
+
+    private val viewModel by viewModels<GameResultViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            GameResultScreen(viewModel = viewModel)
+        }
+
+        collectUiState()
+        blockOnBackPressed()
+    }
+
+    private fun blockOnBackPressed() {
+        onBackPressedDispatcher.addCallback(this) {
+        }
+    }
+
+    private fun collectUiState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { uiState ->
+                    when (uiState) {
+                        ResultUiState.Loading -> {}
+                        ResultUiState.Complete -> {
+                            setResult(
+                                RESULT_OK,
+                                Intent(
+                                    this@GameResultActivity,
+                                    MainActivity::class.java
+                                ).apply {
+                                    putExtra(MainActivity.KEY_USERCOUNT, viewModel.userCount.value)
+                                    putExtra(MainActivity.KEY_RESET, true)
+                                }
+                            )
+                            finish()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultComposable.kt
+++ b/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultComposable.kt
@@ -1,0 +1,275 @@
+package com.example.luckycardgame.presentation.result
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.luckycardgame.R
+import com.example.luckycardgame.data.model.AnimalType
+
+
+@Composable
+fun GameResultScreen(
+    modifier: Modifier = Modifier,
+    viewModel: GameResultViewModel
+) {
+    val userCount by viewModel.userCount.collectAsStateWithLifecycle()
+    val matchedCardsOfUsers by viewModel.matchedCards.collectAsStateWithLifecycle()
+    val winners by viewModel.winners.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = { GameResultTopText() },
+        bottomBar = {
+            GameResultBottomArea(
+                winners = winners,
+                backToMain = viewModel::backToMain
+            )
+        }
+    ) {
+        GameResultMainArea(
+            modifier = Modifier.padding(it),
+            userCount = userCount,
+            matchedCardsOfUsers = matchedCardsOfUsers,
+            winners = winners
+        )
+    }
+}
+
+@Composable
+fun GameResultMainArea(
+    modifier: Modifier = Modifier,
+    userCount: Int,
+    matchedCardsOfUsers: Map<Int, Set<Int>>,
+    winners: Set<Int>
+) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp
+    val screenHeight = LocalConfiguration.current.screenHeightDp
+
+    Column(modifier = modifier) {
+        repeat(userCount) { userId ->
+            PlayerCardRow(
+                modifier = Modifier.padding(12.dp),
+                text = "${'A' + userId}",
+                isWinner = userId in winners,
+                screenWidth = screenWidth,
+                rowHeight = (screenHeight.toDouble() * 0.125).toInt(),
+                cardNums = matchedCardsOfUsers[userId] ?: emptySet()
+            )
+        }
+    }
+}
+
+@Composable
+fun PlayerCardRow(
+    modifier: Modifier = Modifier,
+    text: String,
+    isWinner: Boolean,
+    screenWidth: Int,
+    rowHeight: Int,
+    cardNums: Set<Int>
+) {
+    val animalTypes = remember { AnimalType.values() }
+    val rowWidth = (screenWidth.toDouble() * 0.8)
+
+    Row(
+        modifier = modifier
+            .background(
+                color = if (isWinner) colorResource(id = R.color.red_light)
+                else colorResource(id = R.color.gray_light),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .fillMaxWidth()
+            .height(rowHeight.dp)
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(16.dp)
+                .align(Alignment.CenterVertically),
+            text = text,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.gray_blur),
+            fontSize = 30.sp
+        )
+
+        Spacer(
+            modifier = Modifier
+                .width(8.dp)
+        )
+
+        val cardCount = cardNums.size * animalTypes.size
+        val cardWidth = (rowWidth * 0.8 / cardCount).toInt()
+        cardNums.forEach { num ->
+            animalTypes.forEach { animal ->
+                PlayerCard(
+                    modifier = Modifier
+                        .padding(4.dp),
+                    cardNum = num,
+                    animalType = animal,
+                    width = cardWidth,
+                    height = rowHeight
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun PlayerCard(
+    modifier: Modifier = Modifier,
+    cardNum: Int,
+    animalType: AnimalType,
+    width: Int,
+    height: Int
+) {
+    Box(
+        modifier = modifier
+            .width(width.dp)
+            .height(height.dp)
+            .border(
+                border = BorderStroke(1.dp, colorResource(id = R.color.black)),
+                shape = RoundedCornerShape(16.dp)
+            )
+            .background(
+                color = colorResource(id = R.color.white),
+                shape = RoundedCornerShape(16.dp)
+            )
+    ) {
+        Text(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(8.dp),
+            text = "$cardNum",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Text(modifier = Modifier.align(Alignment.Center), text = animalType.emoji)
+        Text(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(8.dp),
+            text = "$cardNum",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+fun GameResultTopText(
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = "게임결과",
+        fontSize = 24.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+    )
+}
+
+@Composable
+fun GameResultBottomArea(
+    modifier: Modifier = Modifier,
+    winners: Set<Int>,
+    backToMain: () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            text = "이번 게임은 ${winners.map { 'A' + it }.joinToString(", ")}가 승리했습니다.",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(60.dp),
+            contentPadding = PaddingValues(8.dp),
+            shape = RectangleShape,
+            onClick = backToMain
+        ) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.CenterVertically),
+                text = "재시작",
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewGameResultBottomArea() {
+    GameResultBottomArea(
+        winners = setOf(0, 3, 4),
+        backToMain = {}
+    )
+}
+
+@Preview
+@Composable
+fun PreviewMainArea() {
+    GameResultMainArea(
+        userCount = 3,
+        matchedCardsOfUsers = mapOf(0 to setOf(1), 1 to setOf(2), 2 to setOf(3)),
+        winners = setOf(0, 1)
+    )
+}
+
+@Preview
+@Composable
+fun PreviewPlayerCardRow() {
+    PlayerCardRow(
+        text = "A",
+        isWinner = false,
+        screenWidth = 400,
+        rowHeight = 100,
+        cardNums = setOf(1)
+    )
+}
+
+@Preview
+@Composable
+fun PreviewAnimalCard() {
+    PlayerCard(
+        cardNum = 1,
+        animalType = AnimalType.DOG,
+        width = 100,
+        height = 150
+    )
+}

--- a/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultViewModel.kt
+++ b/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultViewModel.kt
@@ -16,7 +16,7 @@ class GameResultViewModel @Inject constructor(
     private val _userCount = MutableStateFlow(luckyGame.getUserCount())
     val userCount: StateFlow<Int> get() = _userCount
 
-    private val _matchedCards = MutableStateFlow<Map<Int, Set<Int>>>(luckyGame.getCardsOfWinners())
+    private val _matchedCards = MutableStateFlow<Map<Int, Set<Int>>>(luckyGame.getMatchedCardsOfUsers())
     val matchedCards: StateFlow<Map<Int, Set<Int>>> get() = _matchedCards
 
     private val _winners = MutableStateFlow(luckyGame.getWinners())

--- a/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultViewModel.kt
+++ b/app/src/main/java/com/example/luckycardgame/presentation/result/GameResultViewModel.kt
@@ -1,0 +1,36 @@
+package com.example.luckycardgame.presentation.result
+
+
+import androidx.lifecycle.ViewModel
+import com.example.luckycardgame.data.model.LuckyGame
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class GameResultViewModel @Inject constructor(
+    private val luckyGame: LuckyGame
+): ViewModel() {
+
+    private val _userCount = MutableStateFlow(luckyGame.getUserCount())
+    val userCount: StateFlow<Int> get() = _userCount
+
+    private val _matchedCards = MutableStateFlow<Map<Int, Set<Int>>>(luckyGame.getCardsOfWinners())
+    val matchedCards: StateFlow<Map<Int, Set<Int>>> get() = _matchedCards
+
+    private val _winners = MutableStateFlow(luckyGame.getWinners())
+    val winners: StateFlow<Set<Int>> get() = _winners
+
+    private val _uiState = MutableStateFlow<ResultUiState>(ResultUiState.Loading)
+    val uiState: StateFlow<ResultUiState> get() = _uiState
+
+    fun backToMain() {
+        _uiState.value = ResultUiState.Complete
+    }
+}
+
+sealed interface ResultUiState {
+    object Loading: ResultUiState
+    object Complete: ResultUiState
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,5 @@
     <color name="gray_light">#d9d9d9</color>
     <color name="gray">#616161</color>
     <color name="gray_blur">#80616161</color>
+    <color name="red_light">#f3acaa</color>
 </resources>


### PR DESCRIPTION
# PR 내용
### Main 화면 - 결과 화면 연결
* `registerForActivityResult`로 연결: deprecated된 `startActivityForResult` 대신 활용.  
* 승자 확인 화면의 `setResult`로 `userCount`를 `MainActivity`에 전달해 그에 맞게 게임을 리셋 (근데 이제보니 `LuckyGame`에 저장된 변수라서 굳이 전달할 필요가 있나 싶습니다.)
* `startResult: ActivityResultLauncher`: ViewModel의 `endFlag`가 `true`가 되면, 승자가 존재하는지 확인 후에 존재한다면 `startResult`의 `launch` 함수로 `GameResultActivity`로 이동

### 승자 판단 기능 추가 구현
* `matchedCardsOfUsers: MutableMap<Int, Set<Int>`: 유저 별 3장 매칭된 카드의 번호를 기록

### 결과 화면 구현 - `GameResultActivity` & `GameResultComposable`
* `GameResultViewModel`: View가 화면에 그려지기 전에 `LuckyGame`의 게임 결과 관련 데이터를 참조하여 `StateFlow`에 보관
* `onBackPressedDispatcher`: deprecated된 `onBackPressed`를 대신해 사용. 결과화면에서 백버튼으로 Main 화면으로 가지 못하게 차단.
* 이외 `GameResultActivity`의 레이아웃은 Compose로 구현

### 결과 확인 (게임 종료 케이스가 너무 안 나와서 캡처해놨습니다)
<img src="https://github.com/softeerbootcamp-2nd/android-luckycardgame/assets/39405316/b51d0bfb-b1e0-4cdf-bc34-f57227082609" width=400>
